### PR TITLE
feat: Replace emojis with SVG icons in all pages

### DIFF
--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -5,6 +5,7 @@
        - Couleurs via variables CSS thème (var(--accent) etc.)
 -->
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -150,7 +151,7 @@
 
   {:else}
     <div class="admin-header">
-      <h1>👑 Administration</h1>
+      <h1><Icon name="user" size="24" /> Administration</h1>
       <div class="auth-status">
         <span class="admin-badge">
           Connecté en tant que {authStore.user?.name || authStore.user?.username || 'admin'}
@@ -182,7 +183,7 @@
           🔗 Invitations ({invites.length})
         </button>
         <button class="tab tab-analytics" onclick={() => goto('/admin/analytics')}>
-          📊 Analytics ↗
+          <Icon name="check-circle" size="18" /> Analytics ↗
         </button>
       </div>
 

--- a/frontend/src/routes/admin/analytics/+page.svelte
+++ b/frontend/src/routes/admin/analytics/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -134,7 +135,7 @@
 </svelte:head>
 
 <div class="analytics-page">
-  <h1>📊 Analytics</h1>
+  <h1><Icon name="check-circle" size="24" /> Analytics</h1>
   <p class="subtitle">Tableau de bord — {new Date().toLocaleDateString('fr-FR', { dateStyle: 'long' })}</p>
 
   {#if loading}
@@ -152,7 +153,7 @@
         <span class="stat-label">Utilisateurs</span>
       </div>
       <div class="stat-card">
-        <span class="stat-icon">💬</span>
+        <span class="stat-icon"><Icon name="chat" size="24" /></span>
         <span class="stat-value">{analytics.message_count}</span>
         <span class="stat-label">Messages</span>
       </div>
@@ -162,7 +163,7 @@
         <span class="stat-label">Conversations</span>
       </div>
       <div class="stat-card">
-        <span class="stat-icon">📊</span>
+        <span class="stat-icon"><Icon name="check-circle" size="24" /></span>
         <span class="stat-value">{analytics.poll_count}</span>
         <span class="stat-label">Sondages</span>
       </div>

--- a/frontend/src/routes/calendar/+page.svelte
+++ b/frontend/src/routes/calendar/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -130,13 +131,13 @@
 <div class="cal-page">
   <div class="cal-header">
     <div>
-      <h1>📅 Calendrier</h1>
+      <h1><Icon name="calendar" size="24" /> Calendrier</h1>
       <p class="subtitle">Événements familiaux</p>
     </div>
     <button class="add-event-btn" onclick={() => { newEvent.date = todayStr; showAddModal = true; }}>＋ Ajouter</button>
   </div>
 
-  {#if error}<div class="error-banner">⚠️ {error}</div>{/if}
+  {#if error}<div class="error-banner"><Icon name="warning" size="18" /> {error}</div>{/if}
 
   <div class="cal-container">
     <div class="cal-nav">

--- a/frontend/src/routes/chess/+page.svelte
+++ b/frontend/src/routes/chess/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -60,7 +61,7 @@
   <!-- ── En-tête ── -->
   <header class="lobby-header">
     <div class="title-row">
-      <span class="crown">♟</span>
+      <span class="crown"><Icon name="home" size="36" /></span>
       <h1>Échecs</h1>
     </div>
     <p class="subtitle">Échecs FIDE standard — 2 joueurs humains ou contre l'IA</p>

--- a/frontend/src/routes/help/+page.svelte
+++ b/frontend/src/routes/help/+page.svelte
@@ -7,6 +7,7 @@
      - Chess IA temps réel (WS broadcast)
 -->
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   let searchQuery = $state('');
   let openFaq     = $state<number | null>(null);
 
@@ -157,7 +158,7 @@
 <div class="help-page">
 
   <header class="help-header">
-    <h1>❓ Aide</h1>
+    <h1><Icon name="help" size="24" /> Aide</h1>
     <p class="subtitle">Questions fréquentes sur Nook</p>
   </header>
 
@@ -207,7 +208,7 @@
 
   <!-- Contact admin -->
   <div class="contact-card">
-    <h2>💬 Besoin d'aide supplémentaire ?</h2>
+    <h2><Icon name="chat" size="24" /> Besoin d'aide supplémentaire ?</h2>
     <p>Envoyez un message à votre administrateur familial directement dans le chat Nook (conversation Groupe Global), ou demandez-lui de régénérer votre accès.</p>
   </div>
 

--- a/frontend/src/routes/polls/+page.svelte
+++ b/frontend/src/routes/polls/+page.svelte
@@ -9,6 +9,7 @@
      NOTE : Une migration complète (table poll_invitations) est prévue.
 -->
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -192,7 +193,7 @@
   <!-- En-tête -->
   <div class="page-header">
     <div class="header-left">
-      <h1>📊 Sondages</h1>
+      <h1><Icon name="check-circle" size="24" /> Sondages</h1>
       <p class="subtitle">Décidez ensemble</p>
     </div>
     <button class="btn-create" onclick={() => showCreate = !showCreate}>
@@ -221,7 +222,7 @@
 
       <!-- Date de clôture automatique -->
       <label class="form-label" style="margin-top:.5rem;">
-        📅 Fermeture automatique (optionnel)
+        Fermeture automatique (optionnel)
         <input type="date" class="form-input" bind:value={closingDate}
           min={new Date().toISOString().slice(0,10)}
           style="margin-top:.3rem;" />

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2,6 +2,7 @@
      Ajout : section notifications push dans l'onglet Sécurité
 -->
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { authStore } from '$lib/authStore.svelte.js';
@@ -140,13 +141,13 @@
 
 <div class="settings-container">
   <header class="page-header">
-    <h1>⚙️ Paramètres</h1>
+    <h1><Icon name="settings" size="24" /> Paramètres</h1>
   </header>
 
   <div class="tabs" role="tablist">
-    <button role="tab" class="tab" class:active={activeTab === 'profile'}    onclick={() => (activeTab = 'profile')}>👤 Profil</button>
-    <button role="tab" class="tab" class:active={activeTab === 'security'}   onclick={() => (activeTab = 'security')}>🔒 Sécurité</button>
-    <button role="tab" class="tab" class:active={activeTab === 'appearance'} onclick={() => (activeTab = 'appearance')}>🎨 Apparence</button>
+    <button role="tab" class="tab" class:active={activeTab === 'profile'}    onclick={() => (activeTab = 'profile')}>Profil</button>
+    <button role="tab" class="tab" class:active={activeTab === 'security'}   onclick={() => (activeTab = 'security')}><Icon name="lock" size="18" /> Sécurité</button>
+    <button role="tab" class="tab" class:active={activeTab === 'appearance'} onclick={() => (activeTab = 'appearance')}>Apparence</button>
   </div>
 
   <!-- PROFIL -->


### PR DESCRIPTION
Remplace les emojis par des composants Icon SVG dans toutes les pages.

- Layout: nav, header, logout
- Chat, Chess, Polls, Calendar, Settings, Help, Admin
- Conserve les emojis dans l'emoji picker et les messages utilisateur