### PR TITLE
refactor(webrtc): supprime simple-peer — utilise RTCPeerConnection natif

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "dompurify": "^3.2.4",
         "idb-keyval": "^6.2.2",
         "libsodium-wrappers": "^0.8.0",
-        "simple-peer": "^9.11.1",
         "uuid": "^13.0.0",
         "yaml": "^2.4.2"
       },
@@ -551,24 +550,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
       "dev": true,
@@ -619,28 +600,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/callsites": {
@@ -772,6 +731,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -814,10 +774,6 @@
       "version": "1.5.330",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/err-code": {
-      "version": "3.0.1",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -1174,10 +1130,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-browser-rtc": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -1213,24 +1165,6 @@
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "dev": true,
@@ -1261,10 +1195,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1437,6 +1367,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1774,43 +1705,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "dev": true,
@@ -1885,24 +1779,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "dev": true,
@@ -1938,33 +1814,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/simple-peer": {
-      "version": "9.11.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.2",
-        "err-code": "^3.0.1",
-        "get-browser-rtc": "^1.1.0",
-        "queue-microtask": "^1.2.3",
-        "randombytes": "^2.1.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "dev": true,
@@ -1984,13 +1833,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2187,6 +2029,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
     "dompurify": "^3.2.4",
     "idb-keyval": "^6.2.2",
     "libsodium-wrappers": "^0.8.0",
-    "simple-peer": "^9.11.1",
     "uuid": "^13.0.0",
     "yaml": "^2.4.2"
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -31,9 +31,6 @@ export default defineConfig({
           // chart.js — uniquement chargé quand un graphique est affiché
           if (id.includes('chart.js')) return 'chart';
 
-          // simple-peer — uniquement chargé pour les appels WebRTC
-          if (id.includes('simple-peer')) return 'webrtc';
-
           // Svelte runtime — séparé pour maximiser le cache navigateur
           if (id.includes('node_modules/svelte') || id.includes('@sveltejs')) return 'svelte';
 


### PR DESCRIPTION
## Résumé

simple-peer (v9.11.1, unmaintained depuis 2021) n'était plus utilisé dans le codebase. Le projet utilise déjà `RTCPeerConnection` natif dans `webrtc-calls.svelte.ts`.

## Changements
- Supprime `src/lib/webrtc.ts` (wrapper simple-peer, code mort)
- Supprime `simple-peer` des dépendances
- Supprime le chunk `webrtc` dans `vite.config.js`
- Met à jour `package-lock.json`

## Gains
- **1 dépendance obsolète en moins**
- **~148 lignes de code mort supprimées**
- **0 dépendance WebRTC externe** (utilise l'API native du navigateur)

## Tests
- [x] `npm run build` passe
- [x] Aucun import de `simple-peer` restant dans le codebase