### PR TITLE
feat(docker): ajoute healthchecks à tous les services

### DIFF
--- a/.claude/TURN-REPORT.md
+++ b/.claude/TURN-REPORT.md
@@ -1,7 +1,7 @@
-# 🧪 Turn-Server Test Report — arm64
+# 🧪 Turn-Server Test Report — amd64
 
-> Généré par `test-turn.yml` · **2026-04-24 06:57 UTC**
-> Architecture: **arm64** | Run: [24876543112](https://github.com/MX10-AC2N/Nook/actions/runs/24876543112)
+> Généré par `test-turn.yml` · **2026-04-24 06:58 UTC**
+> Architecture: **amd64** | Run: [24876543112](https://github.com/MX10-AC2N/Nook/actions/runs/24876543112)
 
 ---
 
@@ -24,7 +24,7 @@
 ```
 Image: nook-turn:test
 Status: running
-Started: 2026-04-24T06:57:30.538955829Z
+Started: 2026-04-24T06:58:26.070219313Z
 Ports: {"3478/tcp":[{"HostIp":"0.0.0.0","HostPort":"3478"},{"HostIp":"::","HostPort":"3478"}],"3478/udp":[{"HostIp":"0.0.0.0","HostPort":"3478"},{"HostIp":"::","HostPort":"3478"}]}
 ```
 
@@ -65,7 +65,7 @@ tcp   LISTEN 0      4096              [::]:3478         [::]:*
 ## 🖥️ System Info
 
 ```
-Linux runnervm6gd1v 6.14.0-1017-azure #17~24.04.1-Ubuntu SMP Tue Dec  2 18:52:52 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
+Linux runnervmeorf1 6.17.0-1010-azure #10~24.04.1-Ubuntu SMP Fri Mar  6 22:00:57 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
 Docker: Docker version 28.0.4, build b8034c0
 ```
 

--- a/.claude/TURN-REPORT.md
+++ b/.claude/TURN-REPORT.md
@@ -1,7 +1,7 @@
-# 🧪 Turn-Server Test Report — amd64
+# 🧪 Turn-Server Test Report — arm64
 
-> Généré par `test-turn.yml` · **2026-04-12 14:12 UTC**
-> Architecture: **amd64** | Run: [24308555094](https://github.com/MX10-AC2N/Nook/actions/runs/24308555094)
+> Généré par `test-turn.yml` · **2026-04-24 06:57 UTC**
+> Architecture: **arm64** | Run: [24876543112](https://github.com/MX10-AC2N/Nook/actions/runs/24876543112)
 
 ---
 
@@ -24,7 +24,7 @@
 ```
 Image: nook-turn:test
 Status: running
-Started: 2026-04-12T14:12:30.065912779Z
+Started: 2026-04-24T06:57:30.538955829Z
 Ports: {"3478/tcp":[{"HostIp":"0.0.0.0","HostPort":"3478"},{"HostIp":"::","HostPort":"3478"}],"3478/udp":[{"HostIp":"0.0.0.0","HostPort":"3478"},{"HostIp":"::","HostPort":"3478"}]}
 ```
 
@@ -65,7 +65,7 @@ tcp   LISTEN 0      4096              [::]:3478         [::]:*
 ## 🖥️ System Info
 
 ```
-Linux runnervm35a4x 6.17.0-1010-azure #10~24.04.1-Ubuntu SMP Fri Mar  6 22:00:57 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
+Linux runnervm6gd1v 6.14.0-1017-azure #17~24.04.1-Ubuntu SMP Tue Dec  2 18:52:52 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
 Docker: Docker version 28.0.4, build b8034c0
 ```
 

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,2 +1,5 @@
 FROM nginx:alpine
 RUN apk add --no-cache openssl
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+    CMD wget -qO- http://localhost/health || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,13 @@ services:
           cpus: "${CPUS_RESERVATION:-0.5}"
           memory: "${MEMORY_RESERVATION:-256M}"
 
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
     networks:
       - nook-network
 
@@ -61,7 +68,16 @@ services:
       - "${NGINX_SSL_DIR:-./nginx-ssl}:/etc/nginx/ssl"
       - "./nginx-entrypoint.sh:/etc/nginx/ssl/nginx-entrypoint.sh:ro"
     depends_on:
-      - nook
+      nook:
+        condition: service_healthy
+
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
     networks:
       - nook-network
 
@@ -78,8 +94,15 @@ services:
       - "${TURN_CONFIG_DIR:-./turn-config}:/etc/turn-server"
 
     environment:
-      - TURN_SECRET=${TURN_SECRET:-}
+      - TURN_SECRET=***
       - TURN_PORT=${TURN_PORT:-3478}
+
+    healthcheck:
+      test: ["CMD", "pgrep", "turn-server"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
     networks:
       - nook-network

--- a/nginx-local.conf
+++ b/nginx-local.conf
@@ -35,6 +35,13 @@ server {
         charset utf-8;
     }
 
+    # Healthcheck endpoint (pas de SSL requis)
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+
     # Rediriger tout le reste vers HTTPS
     location / {
         return 301 https://$host$request_uri;

--- a/services/turn-rs/Dockerfile
+++ b/services/turn-rs/Dockerfile
@@ -41,4 +41,7 @@ COPY --from=builder /usr/local/bin/turn-server /usr/local/bin/turn-server
 
 EXPOSE 3478/udp 3478/tcp
 
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+    CMD pgrep turn-server || exit 1
+
 CMD ["/usr/local/bin/turn-server", "--config=/etc/turn-server/config.toml"]


### PR DESCRIPTION
## Résumé

Ajoute des healthchecks Docker à tous les services de l'application pour une orchestration plus robuste.

## Changements

### Services concernés
| Service | Méthode | Endpoint |
|---------|---------|----------|
| `nook` (backend) | `wget` | `http://localhost:3000/api/health` |
| `nginx-local` | `wget` | `http://localhost/health` (port 80, sans SSL) |
| `turn` | `pgrep` | `turn-server` process |

### Fichiers modifiés
- **Dockerfile.nginx** — ajoute `HEALTHCHECK` via wget
- **nginx-local.conf** — nouvel endpoint `/health` sur le serveur HTTP port 80
- **services/turn-rs/Dockerfile** — ajoute `HEALTHCHECK` via pgrep
- **docker-compose.yml** :
  - Healthchecks explicites pour tous les services
  - `depends_on` avec `condition: service_healthy` pour nginx-local
  - `start_period` pour laisser le temps aux services de démarrer

## Bénéfices
- **nginx ne démarre que quand nook est ready** — plus d'erreurs 502 au démarrage
- **`docker compose ps`** montre l'état de santé de chaque service
- **Restart automatique** si un service devient unhealthy
- **Déploiement plus fiable** sur CasaOS / Docker Swarm

## Tests recommandés
```bash
docker compose up -d
docker compose ps  # doit montrer (healthy) pour tous les services
```