### PR TITLE
Fix: Musl build + Alpine for Docker

### DIFF
--- a/.github/workflows/Backend.yml
+++ b/.github/workflows/Backend.yml
@@ -1,4 +1,5 @@
 name: 1 ==> Backend Build & Artifact
+
 on:
   workflow_dispatch:
 
@@ -13,10 +14,10 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
           - arch: arm64
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             runner: ubuntu-latest
 
     runs-on: ${{ matrix.runner }}
@@ -36,16 +37,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
           components: rustfmt, clippy
+          targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools for arm64
-        if: matrix.arch == 'arm64'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          rustup target add aarch64-unknown-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -107,7 +103,6 @@ jobs:
           mkdir -p artifacts
           cp target/${{ matrix.target }}/release/nook-backend artifacts/nook-backend-${{ matrix.arch }}
           echo "artifacts/nook-backend-${{ matrix.arch }} ready"
-          ls -la artifacts/
 
       - name: Generate BACKEND-BUILD-REPORT
         if: always()
@@ -127,7 +122,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: nook-backend-${{ matrix.arch }}
-          path: backend/artifacts/nook-backend-${{ matrix.arch }}
+          name: nook-backend-${{ matrix.target }}
+          path: backend/artifacts/nook-backend-*
           if-no-files-found: error
           retention-days: 7

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,15 +1,12 @@
 # Nook - Backend (runtime only, pre-compiled binary)
-# Uses Debian Slim for glibc compatibility (binary compiled with x86_64-unknown-linux-gnu)
+# Using Alpine for minimal attack surface and compatibility with musl builds
+FROM alpine:3.19 AS runtime
 
-FROM debian:bookworm-slim AS runtime
-
-RUN apt-get update && apt-get install -y \
+RUN apk add --no-cache \
+    sqlite-libs \
+    libsodium \
     ca-certificates \
-    libsqlite3-0 \
-    libsodium23 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --uid 1000 --group nook
+    && addgroup -g 1000 nook && adduser -D -u 1000 -G nook nook
 
 RUN mkdir -p /app/data/uploads /app/logs /app/static \
     && chown -R nook:nook /app \


### PR DESCRIPTION
Switch to musl target to fix GLIBC_2.38 error on Alpine.