### PR TITLE
fix(db): restore 004_polls.sql migration (fix Migrate VersionMissing(4))

### DIFF
--- a/backend/migrations/004_polls.sql
+++ b/backend/migrations/004_polls.sql
@@ -1,0 +1,49 @@
+-- migrations/004_polls.sql
+-- Sondages familiaux — Session 27
+-- Timestamps INTEGER (Unix epoch), cohérent avec 001_initial.sql
+
+-- ════════════════════════════════════════════════════════════════
+-- TABLE polls
+-- ════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS polls (
+    id         TEXT    PRIMARY KEY,
+    question   TEXT    NOT NULL,
+    created_by TEXT    NOT NULL,
+    created_at INTEGER NOT NULL,
+    closed_at  INTEGER,            -- NULL = ouvert
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_polls_created_at ON polls(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_polls_created_by ON polls(created_by);
+
+-- ════════════════════════════════════════════════════════════════
+-- TABLE poll_options
+-- ════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS poll_options (
+    id       TEXT    PRIMARY KEY,
+    poll_id  TEXT    NOT NULL,
+    text     TEXT    NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_poll_options_poll ON poll_options(poll_id, position);
+
+-- ════════════════════════════════════════════════════════════════
+-- TABLE poll_votes
+-- 1 vote par utilisateur par sondage, modifiable via UPSERT
+-- ════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS poll_votes (
+    poll_id   TEXT    NOT NULL,
+    user_id   TEXT    NOT NULL,
+    option_id TEXT    NOT NULL,
+    voted_at  INTEGER NOT NULL,
+    PRIMARY KEY (poll_id, user_id),
+    FOREIGN KEY (poll_id)   REFERENCES polls(id)        ON DELETE CASCADE,
+    FOREIGN KEY (user_id)   REFERENCES users(id)        ON DELETE CASCADE,
+    FOREIGN KEY (option_id) REFERENCES poll_options(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_poll_votes_poll   ON poll_votes(poll_id);
+CREATE INDEX IF NOT EXISTS idx_poll_votes_option ON poll_votes(option_id);


### PR DESCRIPTION
## Problème

Le déploiement v0.5.0-beta.1 échoue au boot avec `Error: Migrate(VersionMissing(4))` sur les DB existantes (homeserver) qui ont `version=4` dans `_sqlx_migrations`.

## Cause

`backend/migrations/004_polls.sql` a été supprimé du repo (commit `6aa64269`, remplacé par `020_polls.sql` qui fait DROP+CREATE avec `conversation_id`). Les DB déjà migrées ont `version=4` enregistrée dans `_sqlx_migrations`, mais `sqlx::migrate!("./migrations")` ne trouve plus le fichier `004` → refuse de booter.

## Fix (durable)

Restaure `backend/migrations/004_polls.sql` avec le contenu **original exact** (checksum SQLx doit matcher pour les DB existantes).

- Contenu récupéré depuis `git show 57b6fa26~1:backend/migrations/004_polls.sql` (== `6aa64269~1`, sha256 `7ba53cc2...`, 2781 octets, byte-identical vérifié par `cmp`)
- `CREATE TABLE IF NOT EXISTS polls` + `poll_options` + `poll_votes` + index, **SANS** `conversation_id`
- `020_polls.sql` **non modifié** — il fera son DROP+CREATE comme prévu (table avec `conversation_id`)
- Aucun fichier renuméroté

## Validation

1. ✅ `cargo check --all-targets` (SQLX_OFFLINE) passe — 0 erreur, warnings pré-existants uniquement (e2ee.rs tests)
2. ✅ DB fraîche migre sans erreur (17 migrations appliquées)
3. ✅ DB simulée avec `version=4` dans `_sqlx_migrations` migre **sans VersionMissing** ; `020_polls.sql` s'exécute (DROP+CREATE, `polls.conversation_id` présent)
4. ✅ Checksum SQLx de v4 identique entre DB fraîche et DB existante (`dda34d9a...`)

## Fichiers modifiés

- `backend/migrations/004_polls.sql` (restauré, +49 lignes)